### PR TITLE
Fix possible crash on login

### DIFF
--- a/src/components/modals/wallet-login.tsx
+++ b/src/components/modals/wallet-login.tsx
@@ -107,6 +107,7 @@ const WalletLoginModal: FC<custom_props> = ({
   };
 
   const handle_file_upload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    localStorage.removeItem(FINBYTE_WALLET_NAME);
     const file = e.target.files?.[0];
     if (!file) return;
 


### PR DESCRIPTION
- fixes potential crash where 2 wallets are stored in the local storage
- i want to add a note that any commit made directly on github is usually an emergency update